### PR TITLE
feat(admin access): Rework the admin pages and functionality

### DIFF
--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -1,0 +1,143 @@
+import React, { Component } from "react";
+import Loader from "react-loader";
+import { notify } from "react-notify-toast";
+import axiosInstance from "./common/Apicalls";
+import Meal from "./Meal";
+import Add from "./Add";
+
+class AdminDashboard extends Component {
+  state = {
+    meals: [],
+    loaded: false
+  };
+  //get all meals created by admin
+  getMeals = () => {
+    axiosInstance
+      .get("/meals")
+      .then(response => {
+        const meals = response.data.meal_items;
+        this.setState({ meals, loaded: true });
+      })
+      .catch(error => {
+        if (error.response) {
+          const { status } = error.response;
+          if (status === 404) {
+            this.setState({
+              meals: []
+            });
+          } else if (status === 401) {
+            localStorage.removeItem("token");
+          }
+        } else if (error.request) {
+          notify.show("Wrong request", "warning", 4000);
+        }
+      });
+  };
+
+  // always called before the component's first render
+  // fetches the meals list
+  componentWillMount() {
+    this.getMeals();
+  }
+
+  //delete meal from meals list
+  ConfirmDelete(id) {
+    axiosInstance.delete(`/meals/${id}`).then(response => {
+      notify.show(response.data.message, "success", 4000);
+      document.getElementById(`cancelModal${id}`).click();
+      this.getMeals();
+    });
+  }
+
+  //edit meal on meals list
+  EditMeal(id, meal_name, price) {
+    axiosInstance
+      .put(`/meals/${id}`, {
+        meal_name,
+        price
+      })
+      .then(response => {
+        notify.show(response.data.message, "success", 4000);
+        document.getElementById(`closeEditModal${id}`).click();
+        this.getMeals();
+      })
+      .catch(error => {
+        if (error.response) {
+          this.setState({ message: error.response.data.message });
+        } else if (error.request) {
+          notify.show("Network error", "error", 4000);
+        }
+      });
+  }
+  //add meal to menu
+  handleAddMenu = (id, meal_name, price) => {
+    axiosInstance
+      .post(`/menu/${id}`)
+      .then(response => {
+        const menu = response.data;
+        this.setState({ menu });
+        notify.show(response.data.message, "success", 4000);
+      })
+      .catch(error => {
+        if (error.response) {
+          const { status } = error.response;
+          if (status === 404) {
+            this.setState({
+              menu: []
+            });
+          }
+          if (status === 409) {
+            notify.show(error.response.data.message, "error", 4000);
+          }
+        } else if (error.request) {
+          notify.show("Network error", "error", 4000);
+        }
+      });
+  };
+  render() {
+    const { meals, loaded } = this.state;
+
+    const mealDetails =
+      meals.length === 0 ? (
+        <div>No Meals Found</div>
+      ) : (
+        meals.map(meal => (
+          <div key={meal.id}>
+            <Meal
+              handleAddMenu={this.handleAddMenu}
+              ConfirmDelete={() => this.ConfirmDelete(meal.id)}
+              EditMeal={this.EditMeal}
+              id={meal.id}
+              mealName={meal.meal_name}
+              price={meal.price}
+              key={meal.id}
+              message={this.state.message}
+            />
+          </div>
+        ))
+      );
+
+    return (
+      <div className="container-fluid">
+        <button
+          type="button"
+          className="btn btn-primary"
+          data-toggle="modal"
+          data-target="#addModal"
+        >
+          New Meal
+        </button>
+        <div className="row">
+          <div className="meal-list">
+            <h2 className="header text-center">Meals List</h2>
+            <Loader loaded={loaded}>
+              <div className="row">{mealDetails}</div>
+            </Loader>
+          </div>
+        </div>
+        <Add getMeals={this.getMeals} />
+      </div>
+    );
+  }
+}
+export default AdminDashboard;

--- a/src/components/AdminMenu.js
+++ b/src/components/AdminMenu.js
@@ -1,0 +1,119 @@
+import React, { Component } from "react";
+import Loader from "react-loader";
+import axiosInstance from "./common/Apicalls";
+import { notify } from "react-notify-toast";
+import Menu from "./Menu";
+
+class AdminMenu extends Component {
+  state = {
+    menu: [],
+    loaded: false
+  };
+  getMenu = () => {
+    axiosInstance
+      .get("/menu")
+      .then(response => {
+        const menu = response.data.Menu;
+        this.setState({ menu, loaded: true });
+      })
+      .catch(error => {
+        if (error.response) {
+          const { status } = error.response;
+          if (status === 404) {
+            this.setState({
+              menu: []
+            });
+          } else if (status === 401) {
+            localStorage.removeItem("token");
+          }
+        } else if (error.request) {
+          notify.show("Wrong request", "warning", 4000);
+        }
+      });
+  };
+  handleAddOrder = (id, meal_id, meal_name, price) => {
+    axiosInstance
+      .post(`/orders/${id}/${meal_id}`)
+      .then(response => {
+        const orders = response.data;
+        this.setState({ orders });
+        notify.show(response.data.message, "success", 4000);
+      })
+      .catch(error => {
+        if (error.response) {
+          const { status } = error.response;
+          if (status === 404) {
+            this.setState({
+              orders: []
+            });
+          }
+        } else if (error.request) {
+          notify.show("Wrong request", "error", 4000);
+        }
+      });
+  };
+
+  componentWillMount() {
+    this.getMenu();
+  }
+  render() {
+    let daysList = [
+      { dataDay: "monday", value: "Monday" },
+      { dataDay: "tuesday", value: "Tuesday" },
+      { dataDay: "wednesday", value: "Wednesday" },
+      { dataDay: "thursday", value: "Thursday" },
+      { dataDay: "friday", value: "Friday" },
+      { dataDay: "saturday", value: "Saturday" },
+      { dataDay: "sunday", value: "Sunday" }
+    ];
+    let days = daysList.map((day, i) => (
+      <li key={i} className="list-group-item">
+        <button className="btn btn-block btn-lg" data-day={day.dataDay}>
+          {day.value}
+        </button>
+      </li>
+    ));
+
+    const { menu, loaded } = this.state;
+    const menuDetails =
+      menu.length === 0 ? (
+        <div>No Menu Found</div>
+      ) : (
+        menu.map(menumeal => (
+          <div key={menumeal.id}>
+            <Menu
+              id={menumeal.id}
+              mealName={menumeal.meal_name}
+              price={menumeal.price}
+              key={menumeal.id}
+              handleAddOrder={this.handleAddOrder}
+            />
+          </div>
+        ))
+      );
+
+    return (
+      <div className="row">
+        <div className="col-md-2">
+          <div className="header">Days</div>
+          <ul className="list-group">{days}</ul>
+        </div>
+        <div className="col-md-6 meal-list">
+          <h2 className="header text-center">Menu List</h2>
+          <Loader loaded={loaded}>
+            <div className="row">{menuDetails}</div>
+          </Loader>
+        </div>
+        <div className="col-md-4">
+          <div className="ordered">
+            <div className="header text-center">Order</div>
+            {/* <Loader loaded={loaded}>
+              <div className="row">{Orders}</div>
+            </Loader> */}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+export default AdminMenu;

--- a/src/components/Meal.js
+++ b/src/components/Meal.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Delete from "./Delete";
+import Edit from "./Edit";
+
+//meal card: admin side
+const Meal = props => (
+  <div className="card mb-2 meal" style={{ width: "12rem", height: "8rem" }}>
+    <div className="card-body text-center">
+      <div className="card-text"> {props.mealName}</div>
+      <div className="card-text">{props.price}</div>
+      <div className="row">
+        <Link
+          to="#"
+          data-toggle="modal"
+          className="btn btn-primary btn-sm mealcard"
+          data-target="#menuModal"
+          onClick={() =>
+            props.handleAddMenu(props.id, props.mealName, props.price)
+          }
+        >
+          Add
+        </Link>
+        <Link
+          to="#"
+          data-toggle="modal"
+          data-target={`#EditModal${props.id}`}
+          className="btn btn-success btn-sm mealcard"
+        >
+          Edit
+        </Link>
+        <Link
+          to="#"
+          className="btn btn-danger btn-sm"
+          data-toggle="modal"
+          data-target={`#deleteModal${props.id}`}
+        >
+          Delete
+        </Link>
+      </div>
+      <Delete
+        id={props.id}
+        meal_name={props.mealName}
+        ConfirmDelete={props.ConfirmDelete}
+      />
+      <Edit
+        meal_name={props.mealName}
+        id={props.id}
+        price={props.price}
+        EditMeal={props.EditMeal}
+        message={props.message}
+      />
+    </div>
+  </div>
+);
+
+export default Meal;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+//menu meal card: admin side
+const Menu = props => (
+  <div className="card mb-2 meal" style={{ width: "12rem", height: "8rem" }}>
+    <div className="card-body text-center">
+      <div className="card-text"> {props.mealName}</div>
+      <div className="card-text">{props.price}</div>
+      <div className="row">
+        <Link
+          to="#"
+          className="btn btn-primary btn-sm centered"
+          data-toggle="modal"
+          data-target="#orderModal"
+          onClick={() =>
+            props.handleAddOrder(props.id, props.mealName, props.price)
+          }
+        >
+          Add
+        </Link>
+      </div>
+    </div>
+  </div>
+);
+export default Menu;

--- a/src/components/common/Auth.js
+++ b/src/components/common/Auth.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Redirect, Route } from "react-router-dom";
+
+const AuthRoute = ({ component: Component, ...rest }) => {
+  //check the localStorage for the token
+  const token = localStorage.getItem("token");
+  return (
+    <Route
+      {...rest}
+      render={props => {
+        return token === null ? <Redirect to="/login" /> : <Component />;
+      }}
+    />
+  );
+};
+
+export default AuthRoute;


### PR DESCRIPTION
#### What does this PR do?
Have the admin pages accessible by admins. Allows admins to create, edit and delete meals, add meals to the menu.

#### Description of Task to be completed?
The admin has the ability to do CRUD functionality.

#### How should this be manually tested?
After cloning the repo, cd into the project and run yarn start.
On creating an account, sign up as an admin/caterer to be able to access the admin pages.

#### What are the relevant pivotal tracker stories?
[#159764089](https://www.pivotaltracker.com/story/show/159764089)

#### Screenshots (if appropriate)
